### PR TITLE
Fix incorrect year in release dates

### DIFF
--- a/amdversions.xml
+++ b/amdversions.xml
@@ -6,7 +6,7 @@
         <internal-version>24.20.33.05</internal-version>
         <windows-version>32.0.12033.5029</windows-version>
         <vulkan-version>2.0.317</vulkan-version>
-        <release-date>2024-02-11</release-date>
+        <release-date>2025-02-11</release-date>
     </driver>
     <driver version="25.1.1" operating-system="Windows">
         <whql>Optional</whql>
@@ -14,7 +14,7 @@
         <internal-version>24.20.33.05</internal-version>
         <windows-version>32.0.12033.5010</windows-version>
         <vulkan-version>2.0.317</vulkan-version>
-        <release-date>2024-01-23</release-date>
+        <release-date>2025-01-23</release-date>
     </driver>
     <driver version="24.12.1" operating-system="Windows">
         <whql>WHQL</whql>


### PR DESCRIPTION
Hi, I noticed the release date years are incorrect for the last two releases - they are listed as 2024, but should be 2025.